### PR TITLE
https by default

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -166,7 +166,7 @@ func generateRandomBytes(n int) ([]byte, error) {
 
 func main() {
 	apiKey := flag.String("apiKey", "", "apiKey")
-	host := flag.String("host", "api.peacemakr.io", "host of Peacemakr services")
+	peacemakrUrl := flag.String("peacemakrUrl", "https://api.peacemakr.io", "URL of Peacemakr cloud services")
 	numCryptoTrips := flag.Int("numCryptoTrips", 100, "Total number of example encrypt and decrypt operations.")
 	numEncryptThreads := flag.Int("numEncryptClients", 1, "Total number of encryption clients. (1)")
 	numDecryptThreads := flag.Int("numDecryptClients", 10, "Total number of decryption clients. (10)")
@@ -177,7 +177,7 @@ func main() {
 	}
 
 	log.Println("apiKey:", *apiKey)
-	log.Println("host:", *host)
+	log.Println("peacemakrUrl:", *peacemakrUrl)
 	log.Println("numCryptoTrips:", *numCryptoTrips)
 	log.Println("numEncryptThreads:", *numEncryptThreads)
 	log.Println("numDecryptThreads:", *numDecryptThreads)
@@ -190,7 +190,7 @@ func main() {
 	// Just one decryptor
 
 	for i := 0; i < *numDecryptThreads; i++ {
-		go runDecryptingClient(i, *apiKey, *host, encrypted)
+		go runDecryptingClient(i, *apiKey, *peacemakrUrl, encrypted)
 	}
 
 	// Fire up the encryption clients.
@@ -198,12 +198,12 @@ func main() {
 
 		// Do it once with indiscriminate useDomains.
 		encryptionWork.Add(1)
-		go runEncryptingClient(i, *apiKey, *host, *numCryptoTrips, encrypted, &encryptionWork, "")
+		go runEncryptingClient(i, *apiKey, *peacemakrUrl, *numCryptoTrips, encrypted, &encryptionWork, "")
 
 		// And, again with a specific useDomain.
 		if len(*useDomainName) > 0 {
 			encryptionWork.Add(1)
-			go runEncryptingClient(i, *apiKey, *host, *numCryptoTrips, encrypted, &encryptionWork, *useDomainName)
+			go runEncryptingClient(i, *apiKey, *peacemakrUrl, *numCryptoTrips, encrypted, &encryptionWork, *useDomainName)
 		}
 
 		// Why Sleep? The number of clients can't just explode, need to give them a chance to spin up,

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.12
 
 require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
-	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
-	github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb
 	github.com/go-openapi/analysis v0.19.0 // indirect
 	github.com/go-openapi/errors v0.17.0
 	github.com/go-openapi/jsonpointer v0.19.0 // indirect
@@ -16,17 +14,15 @@ require (
 	github.com/go-openapi/strfmt v0.17.0
 	github.com/go-openapi/swag v0.17.0
 	github.com/go-openapi/validate v0.0.0-20180703152151-9a6e517cddf1
-	github.com/json-iterator/go v1.1.6
+	github.com/json-iterator/go v1.1.6 // indirect
 	github.com/kennygrant/sanitize v1.2.4
-	github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe
+	github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/pquerna/ffjson v0.0.0-20181028064349-e517b90714f7
-	github.com/ugorji/go/codec v1.1.5-pre
+	github.com/pquerna/ffjson v0.0.0-20181028064349-e517b90714f7 // indirect
+	github.com/ugorji/go v1.1.5-pre // indirect
 	golang.org/x/net v0.0.0-20190328230028-74de082e2cca
-	golang.org/x/text v0.3.0
-	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
-	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
+	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/pkg/crypto.go
+++ b/pkg/crypto.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/peacemakr-io/peacemakr-go-sdk/pkg/utils"
 	"log"
+	"net/url"
 	"os"
 	"time"
 )
@@ -96,7 +97,7 @@ type PeacemakrSDK interface {
 //
 // printStackTrace changes the behavior of the SDK's logging; if true then each log message will print a stack trace. Good for debugging
 // when something goes sideways, but can usually be left off.
-func GetPeacemakrSDK(apiKey, clientName string, peacemakrHostname *string, persister utils.Persister, optionalLogger SDKLogger) (PeacemakrSDK, error) {
+func GetPeacemakrSDK(apiKey, clientName string, peacemakrURL *string, persister utils.Persister, optionalLogger SDKLogger) (PeacemakrSDK, error) {
 
 	if persister == nil {
 		return nil, errors.New("persister is required")
@@ -107,6 +108,17 @@ func GetPeacemakrSDK(apiKey, clientName string, peacemakrHostname *string, persi
 		loggerToUse = log.New(os.Stderr, "", log.LstdFlags)
 	}
 
+	peacemakrHost := "api.peacemakr.io"
+	peacemakrScheme := "https"
+	if peacemakrURL != nil {
+		url, err := url.Parse(*peacemakrURL)
+		if err != nil {
+			return nil, err
+		}
+		peacemakrHost = url.Host
+		peacemakrScheme = url.Scheme
+	}
+
 	sdk := &standardPeacemakrSDK{
 		clientName,
 		apiKey,
@@ -114,7 +126,8 @@ func GetPeacemakrSDK(apiKey, clientName string, peacemakrHostname *string, persi
 		nil,
 		utils.GetAuthWriter(apiKey),
 		"0.0.1",
-		peacemakrHostname,
+		peacemakrHost,
+		peacemakrScheme,
 		persister,
 		false,
 		0,

--- a/pkg/crypto_impl.go
+++ b/pkg/crypto_impl.go
@@ -895,7 +895,7 @@ func (sdk *standardPeacemakrSDK) getClient() *client.PeacemakrClient {
 	cfg := client.TransportConfig{
 		Host:     hostname,
 		BasePath: client.DefaultBasePath,
-		Schemes:  []string{"http"},
+		Schemes:  []string{"https"},
 	}
 
 	sdkClient = client.NewHTTPClientWithConfig(nil, &cfg)


### PR DESCRIPTION
Also here:
 * Use a URL instead of a hostname, to specify which peacemakr backend to talk to .... this enables use to continue to use http inhouse for testing, while customers and prod environments my use https externally - without adding more stuff to the actual interface :)
 * Fix to actually use clientName in the debugging logs

Fixes:
https://github.com/peacemakr-io/peacemakr-go-sdk/issues/40
https://github.com/peacemakr-io/peacemakr-go-sdk/issues/37
