### PR TITLE
The server is now speaking in capital RSA and EC in crypto config key…

### DIFF
--- a/pkg/crypto_impl.go
+++ b/pkg/crypto_impl.go
@@ -1123,11 +1123,11 @@ func (sdk *standardPeacemakrSDK) Register() error {
 		}
 
 		if cfg == coreCrypto.RSA_2048 || cfg == coreCrypto.RSA_4096 {
-			keyTy = "rsa"
+			keyTy = "RSA"
 		} else if cfg == coreCrypto.ECDH_P256 ||
 			cfg == coreCrypto.ECDH_P384 ||
 			cfg == coreCrypto.ECDH_P521 {
-			keyTy = "ec"
+			keyTy = "EC"
 		}
 	}
 

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -102,7 +102,7 @@ func publicPemKey(key rsa.PublicKey) string {
 
 func GetNewKey(keyType string, bitlength int) (string, string, string) {
 
-	if keyType == "rsa" {
+	if keyType == "RSA" {
 		reader := rand.Reader
 
 		//
@@ -121,25 +121,25 @@ func GetNewKey(keyType string, bitlength int) (string, string, string) {
 		pemPub := publicPemKey(key.PublicKey)
 		pemPriv := pemString(key)
 
-		return pemPub, pemPriv, "rsa"
-	} else if keyType == "ec" {
+		return pemPub, pemPriv, "RSA"
+	} else if keyType == "EC" {
 		switch bitlength {
 		case 256:
 			pub, priv := getNewECKey(elliptic.P256())
-			return pub, priv, "ec"
+			return pub, priv, "EC"
 		case 384:
 			pub, priv := getNewECKey(elliptic.P384())
-			return pub, priv, "ec"
+			return pub, priv, "EC"
 		case 521:
 			pub, priv := getNewECKey(elliptic.P521())
-			return pub, priv, "ec"
+			return pub, priv, "EC"
 		default:
 			pub, priv := getNewECKey(elliptic.P256())
-			return pub, priv, "ec"
+			return pub, priv, "EC"
 		}
 	} else {
 		// Then, just default to an EC key type of 256 bits.
-		return GetNewKey("ec", 256)
+		return GetNewKey("EC", 256)
 	}
 
 }


### PR DESCRIPTION
… type.

I don't really remember this changing recently, but, the
AdminPortal did start displaying those key types in all
caps a while back. I didn't realize that was an ecosystem
wide change that would impact the representation of data.
Maybe this is not actually the correct fix to this, beacuse
everything references these key types.